### PR TITLE
Remove experimental yarn config from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ git clone https://github.com/chadfurman/rpg-boilerplate.git
 # enter into the folder
 cd rpg-boilerplate
 
-# enable yarn workspaces
-yarn config set workspaces-experimental true
-
 # install dependencies
 yarn install
 


### PR DESCRIPTION
It's no longer necessary thanks to `.yarnrc`